### PR TITLE
fix: Replace build badge.

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,4 +1,4 @@
-name: On push
+name: QA
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: On merge to master
+name: Release
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ semantic-release-configuration contains the semantic-release configuration for t
 | Version          | [![npm](https://img.shields.io/npm/v/semantic-release-configuration)](https://www.npmjs.com/package/semantic-release-configuration)                                                      |
 | Dependencies     | ![David](https://img.shields.io/david/thenativeweb/semantic-release-configuration)                                                                                                       |
 | Dev dependencies | ![David](https://img.shields.io/david/dev/thenativeweb/semantic-release-configuration)                                                                                                   |
-| Build            | [![CircleCI](https://img.shields.io/circleci/build/github/thenativeweb/semantic-release-configuration)](https://circleci.com/gh/thenativeweb/semantic-release-configuration/tree/master) |
+| Build            | [![GitHub Actions](https://github.com/thenativeweb/semantic-release-configuration/workflows/Release/badge.svg)                                                                           |
 | License          | ![GitHub](https://img.shields.io/github/license/thenativeweb/semantic-release-configuration)                                                                                             |
 
 ## Installation


### PR DESCRIPTION
Hey @yeldiRium 👋 

This PR replaces the previous CircleCI-based build badge by one based on GitHub Actions.

Can you please review, squash and merge it, if you are fine with it?